### PR TITLE
feat: default dark theme

### DIFF
--- a/mozaq-studio-next/app/page.tsx
+++ b/mozaq-studio-next/app/page.tsx
@@ -35,7 +35,7 @@ function Reveal({ as: Tag = "div", className = "", children, ...props }: any) {
 export default function Page() {
   // THEME: quad-state (system, dark, editorial, creative)
   const MODE_KEY = "mozaq_theme_mode";
-  const [mode, setMode] = useState<"system"|"dark"|"editorial"|"creative">("system");
+  const [mode, setMode] = useState<"system"|"dark"|"editorial"|"creative">("dark");
   const mql = typeof window !== "undefined" && window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
 
   useEffect(() => {

--- a/mozaq-studio-next/app/page.tsx
+++ b/mozaq-studio-next/app/page.tsx
@@ -101,9 +101,17 @@ export default function Page() {
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
       if (!menuRef.current) return;
-      // @ts-ignore
-      if (!menuRef.current.contains(e.target)) setOpen(false);
+
+      const t = e.target;
+      if (!(t instanceof Node)) {
+        setOpen(false);
+        return;
+      }
+      if (!menuRef.current.contains(t)) {
+        setOpen(false);
+      }
     }
+
     if (open) document.addEventListener("mousedown", onDocClick);
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [open]);


### PR DESCRIPTION
## Summary
- default theme mode to dark

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962d5dd7d48333944ab2f5ad1df6fd